### PR TITLE
fix AttributeError: 'Page' object has no attribute 'getText'

### DIFF
--- a/sci_rename.py
+++ b/sci_rename.py
@@ -115,7 +115,7 @@ def scan_title(full_file_name, page_num=None):
     size_text_tup_list =[]
     title=''
     # get paget text 
-    blocks = page.getText('dict')['blocks']
+    blocks = page.get_text('dict')['blocks']
     for blk in blocks:                              # iterate through text blocks
         if blk['type'] == 0:                        # only considers text blocks (type 0)
             for line in blk['lines']:               # iterate through text lines


### PR DESCRIPTION
```
scientific-paper-pdf-rename/sci_rename.py", line 118, in scan_title
    blocks = page.getText('dict')['blocks']
             ^^^^^^^^^^^^
AttributeError: 'Page' object has no attribute 'getText'. Did you mean: 'get_text'?
```